### PR TITLE
Chore/gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,8 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/*
+!.vscode/settings.json
 
 # Ruff stuff:
 .ruff_cache/

--- a/models/producto.py
+++ b/models/producto.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+class Producto(BaseModel):
+    id: int
+    nombre: str
+    cantidad: int
+    precio: float


### PR DESCRIPTION
- Se actualizó el archivo `.gitignore` para ignorar la carpeta `.vscode` completa
- Se agregó excepción para incluir `settings.json` en control de versiones

Esto permite mantener la configuración mínima de VS Code (como comprobación de tipos con Pylance),
pero evita subir configuraciones locales innecesarias al repositorio.
