### PR TITLE
chore: ajustar .gitignore para ignorar .vscode excepto settings.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,8 @@ cython_debug/
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
 #  and can be added to the global gitignore or merged into this file. However, if you prefer, 
 #  you could uncomment the following to ignore the entire vscode folder
-# .vscode/
+.vscode/*
+!.vscode/settings.json
 
 # Ruff stuff:
 .ruff_cache/


### PR DESCRIPTION
- Se actualizó el archivo `.gitignore` para ignorar la carpeta `.vscode` completa
- Se agregó excepción para incluir `settings.json` en control de versiones

Esto permite mantener la configuración mínima de VS Code (como comprobación de tipos con Pylance),
pero evita subir configuraciones locales innecesarias al repositorio.
