### PR TITLE
endpoint para actualizar el precio del producto

### DIFF
--- a/controllers/producto_controller.py
+++ b/controllers/producto_controller.py
@@ -2,6 +2,7 @@ from typing import List
 from fastapi import APIRouter, HTTPException
 from models.producto import Producto
 from models.movimiento_stock import MovimientoStock
+from models.precio_update import PrecioUpdate
 from repositories.producto_repository import ProductoRepository
 from services.producto_service import ProductoService
 
@@ -45,6 +46,16 @@ def actualizar_producto(id: str, producto: Producto):
         if not updated:
             raise HTTPException(status_code=404, detail="Producto no encontrado")
         return updated
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    
+@router.patch("/{id}/precio", summary="Actualizar solo el precio de un producto")
+def actualizar_precio(id: str, data: PrecioUpdate):
+    try:
+        actualizado = producto_service.actualizar_precio(id, data.precio)
+        if not actualizado:
+            raise HTTPException(status_code=404, detail="Producto no encontrado")
+        return actualizado
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/models/precio_update.py
+++ b/models/precio_update.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel, Field
+
+class PrecioUpdate(BaseModel):
+    precio: float = Field(..., gt=0, description="Nuevo precio del producto")

--- a/services/producto_service.py
+++ b/services/producto_service.py
@@ -71,3 +71,13 @@ class ProductoService:
         producto.stock -= cantidad
         return self.repository.actualizar(producto_id, producto)
 
+    def actualizar_precio(self, producto_id: str, nuevo_precio: float):
+        if nuevo_precio <= 0:
+            raise ValueError("El precio debe ser mayor a 0")
+
+        producto = self.repository.obtener(producto_id)
+        if not producto:
+            return None
+
+        producto.precio = nuevo_precio
+        return self.repository.actualizar(producto_id, producto)


### PR DESCRIPTION
actualiza el precio del producto

se creo el modelo precio_update para:
✔ Mejor documentación Swagger
✔ Validar correctamente
✔ Evitar mandar todo el producto
✔ Evitar que actualicen campos que no deben tocar